### PR TITLE
Add disk usage example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,6 @@ term_size = "0.3.1"
 async-fetcher = { git = "https://github.com/pop-os/async-fetcher" }
 surf = { git = "https://github.com/http-rs/surf" }
 hyper = "0.13.4"
-tokio = {version = "0.2.17", features = ["macros"]}
+tokio = {version = "0.2.17", features = ["fs", "macros"]}
 ctrlc = "3.1.4"
 termios = "0.3.2"

--- a/examples/du.rs
+++ b/examples/du.rs
@@ -1,0 +1,62 @@
+use tokio::spawn;
+use tokio::io::Result;
+use tokio::fs::{read_dir, DirEntry};
+use futures::stream::TryStreamExt;
+
+use progression::{ProgressBarBuilder, ProgressBar};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+
+    let (handle, future) = progression::multi_bar();
+    let future_join = spawn(future);
+
+    read_dir(".")
+        .await?
+        .try_for_each_concurrent(None, |entry| async {
+            let mut handle = handle.clone();
+            let name = entry.file_name().into_string().unwrap();
+            let builder = ProgressBarBuilder::new(format!("{:?}", name), 1);
+            if let Ok(bar) = handle.add_bar(builder) {
+                get_size(name, entry, bar).await.unwrap();
+            }
+
+            Ok(())
+        }).await?;
+
+    handle.finish();
+    future_join.await?;
+
+    Ok(())
+}
+
+async fn get_size(name: String, start: DirEntry, bar: ProgressBar) -> Result<()> {
+    let mut to_visit = vec![start];
+    let mut dirs_visited = 0;
+    let mut dirs_to_visit = 1;
+    let mut bytes = 0;
+
+    while let Some(e) = to_visit.pop() {
+        let meta = e.metadata().await?;
+        bytes += meta.len();
+
+        if meta.is_dir() {
+            let mut children = read_dir(e.path()).await?;
+
+            while let Some(child) = children.next_entry().await? {
+                dirs_to_visit += 1;
+                to_visit.push(child);
+            }
+        }
+
+        dirs_visited += 1;
+
+        bar.set(dirs_visited);
+        bar.update_total(dirs_to_visit);
+        bar.update_name(format!("{}: {}", name, bytes));
+    }
+
+    bar.finish();
+
+    Ok(())
+}

--- a/examples/du.rs
+++ b/examples/du.rs
@@ -51,9 +51,15 @@ async fn get_size(name: String, start: DirEntry, bar: ProgressBar) -> Result<()>
 
         dirs_visited += 1;
 
-        bar.set(dirs_visited);
-        bar.update_total(dirs_to_visit);
-        bar.update_name(format!("{}: {}", name, bytes));
+        // Refresh less often
+        if dirs_visited == dirs_to_visit
+            || (dirs_to_visit < 100 && dirs_visited % 10 == 0)
+            || (dirs_to_visit < 1000 && dirs_visited % 100 == 0)
+            || dirs_visited % 1000 == 0 {
+            bar.set(dirs_visited);
+            bar.update_total(dirs_to_visit);
+            bar.update_name(format!("{}: {}", name, bytes));
+        }
     }
 
     bar.finish();


### PR DESCRIPTION
This is a quick and dirty example to show disk usage in the current directory with progress bars.
I just wanted to try your library :smile:

- The progress estimates are a bit wonky, maybe there's a better heuristic I could follow.
- The progress bars aren't really aligned at the moment. Maybe I need more control over the multi bar rendering?
- I'm not really happy with the blocking Mutex I'm using for the progress bar name. I tried using an async Mutex from futures but it was tricky to get the async code working inside the poll definition, so I gave up that approach.